### PR TITLE
Remove model suffix as this is not recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The guidelines described below are based on:
   │   ├── home-dashboard.component.spec.ts
   │   ├── login.component.ts
   │   ├── login.component.spec.ts
-  │   ├── admin.model.ts
+  │   ├── admin.ts
   │   ├── user-management.service.ts
   │   └── order-management.service.ts
   ├── shared
@@ -78,8 +78,8 @@ The guidelines described below are based on:
       │   ├── register.component.ts
       │   └── register.component.spec.ts
       ├── models
-      │   ├── shopping-cart.model.ts
-      │   ├── shopping-item.model.ts
+      │   ├── shopping-cart.ts
+      │   ├── shopping-item.ts
       │   └── user.ts
       └── services
           └── checkout.service.ts


### PR DESCRIPTION
Further on in the style guide we come across the following recommendation: 

> ```
> // Contains the ShoppingCart model. Notice that there is no suffix for the models.
> shopping-cart.ts
> ```

The directory structure example uses the model suffix though. It might be a good idea to remove it as it might cause confusion otherwise.
