### PR TITLE
docs(Readme.md): fix HostBinding usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ The guidelines described below are based on:
     selector: '[sgSample]'
   })
   class SampleDirective {
-    @HostBinding('role') button;
+    @HostBinding('attr.role') role = 'button';
     @HostListener('mouseenter') onMouseEnter() {...}
   }
   ```


### PR DESCRIPTION
your definition won't work

demo: http://plnkr.co/edit/a2sLDtpTHtB7vS30urg6?p=preview
why: https://angular.io/docs/ts/latest/api/compiler/PropertyBindingType-enum.html#!#sts=Attribute

so IMO is better to use `@Directive/@Component` `host` property for these kinds of static element DOM attributes, which would not change.
for any other dynamic props of course `@HostBinding` is way to go.

Maybe you should reconsider this rule, wdyt?

thx
